### PR TITLE
Ln1Exp and other numerical optimizations

### DIFF
--- a/ComputerAlgebra/LinqCompiler/StandardMath.cs
+++ b/ComputerAlgebra/LinqCompiler/StandardMath.cs
@@ -7,6 +7,7 @@ namespace ComputerAlgebra.LinqCompiler
     /// </summary>
     public class StandardMath
     {
+        public static double Ln1Exp(double x) => x < -50d ? 0d : (x > 50d ? x : Math.Log(1d + Math.Exp(x)));
         public static double Abs(double x) { return x < 0 ? -x : x; }
         public static double Sign(double x) { return x > 0 ? 1 : (x < 0 ? -1 : 0); }
 

--- a/ComputerAlgebra/LinqCompiler/StandardMath.cs
+++ b/ComputerAlgebra/LinqCompiler/StandardMath.cs
@@ -7,7 +7,13 @@ namespace ComputerAlgebra.LinqCompiler
     /// </summary>
     public class StandardMath
     {
-        public static double Ln1Exp(double x) => x < -50d ? 0d : (x > 50d ? x : Math.Log(1d + Math.Exp(x)));
+        private static double ExpKnee = 50;
+        static StandardMath()
+        {
+            _knee = Math.Exp(ExpKnee);
+            _b = _knee - _knee * ExpKnee;
+        }
+        public static double Ln1Exp(double x) => x > 50d ? x : Math.Log(1d + Math.Exp(x));
         public static double Abs(double x) { return x < 0 ? -x : x; }
         public static double Sign(double x) { return x > 0 ? 1 : (x < 0 ? -1 : 0); }
 
@@ -43,7 +49,11 @@ namespace ComputerAlgebra.LinqCompiler
         public static double ArcCoth(double x) { return ArcTanh(1 / x); }
 
         public static double Sqrt(double x) { return Math.Sqrt(x); }
-        public static double Exp(double x) { return Math.Exp(x); }
+
+        private static double _knee;
+        private static double _b;
+
+        public static double Exp(double x) => x > ExpKnee ? _knee * x + _b : Math.Exp(x);
         public static double Ln(double x) { return Math.Log(x); }
         public static double Log(double x, double b) { return Math.Log(x, b); }
         public static double Pow(double x, double y) { return Math.Pow(x, y); }


### PR DESCRIPTION
Hi, I remember that one time we had a conversation about how to handle numerical optimizations e.g. for `ln(1 + exp(x))` stuff. So, I tested it. Implementation is rather simplistic, and I've just added some code to the `CompileExpression` visitor, but it should be probably done in some more organized way (e.g. separate visitor per optimization). I was wondering if it's possible to use `SubstituteTransform` for that? But this is more like a run-time optimization, and it fits better for the compilation step. I've also tried adding `Ln1Exp` function to the global namespace directly, so it can be used in models, but it causes many problems (e.g. with differentiation). BTW, that's why I had to add a linear extension to the `exp` function, because without `Call.If` in triode models, Computer Algebra produces different results, containing exp function calls in derivatives, which wasn't the case in old version because of how derivatives are handled for function containing `if` expression 😉
``` c#
new SubstituteTransform("D[If[c, t, f], x]", "If[c, D[t, x], D[f, x]]")
``` 
Anyway, I hope that you can point me in the right direction with this 😄